### PR TITLE
initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+lib/
+node_modules/
+
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+examples/
+node_modules/
+src/
+test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+  - "6.1"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# JsonImmutable
+
+[![Build Status](https://travis-ci.org/avocode/json-immutable.svg)](https://travis-ci.org/avocode/json-immutable)
+
+Immutable.JS structure-aware JSON serializer/deserializer built around the native `JSON` API.
+
+## Motivation
+
+By using the native `JSON` API, Immutable.JS structures are serialized as plain objects and arrays with no type information. The goal was to preserve both Immutable.JS `Iterable` types (maps, lists, etc.) and `Record` types. `immutable.Map` supports and preserves key types while plain JavaScript object keys are coerced to strings. These types should also preserved.
+
+## Usage
+
+### Plain Objects and Primitive Types
+
+```javascript
+const data = { 'a': 'b', 'c': 123, 'd': true }
+
+// Serialize
+const json = serialize(data)
+// json == '{"a":"b","c":123,"d":true}'
+
+// Deserialize
+const result = deserialize(json)
+```
+
+### Immutable Records
+
+```javascript
+const SampleRecord = immutable.Record(
+  { 'a': 3, 'b': 4 },
+  'SampleRecord'
+)
+
+const data = {
+  'x': SampleRecord({ 'a': 5 }),
+}
+
+// Serialize
+const json = serialize(data)
+// json == '{"x":{"__record":"SampleRecord","data":{"a":5}}}'
+
+// Deserialize
+const result = deserialize(json, {
+  recordTypes: {
+    'SampleRecord': SampleRecord
+  }
+})
+```
+
+Record types can be named. This is utilized by the serializer/deserializer to revive `immutable.Record` objects. See the `SampleRecord` name passed into `immutable.Record()` as the second argument.
+
+NOTE: When an unknown record type is encountered during deserialization, an error is thrown.
+
+### General Immutable Structures
+
+```javascript
+const data = {
+  'x': immutable.Map({
+    'y': immutable.List.of(1, 2, 3)
+  }),
+}
+
+// Serialization
+const json = serialize(data)
+// json == '{"x":{"__iterable":"Map","data":[["y",{"__iterable":"List","data":[1,2,3]"}]]}}'
+
+// Deserialize
+const result = deserialize(json)
+```
+
+- Immutable structures, plain objects and primitive data can be safely composed together.
+
+- `immutable.Map` key type information is preserved as opposed to the bare `JSON` API.
+
+NOTE: When an unknown Immutable iterable type is encountered during deserialization, an error is thrown. The supported types are `List`, `Map`, `OrderedMap`, `Set`, `OrderedSet` and `Stack`.
+
+## API
+
+- **`serialize()`**
+
+    Arguments:
+
+    - `data`: The data to serialize.
+    - `options={}`: Serialization options.
+        - `pretty=false`: Whether to pretty-print the result (2 spaces).
+
+    Return value:
+
+    - `string`: The JSON representation of the input (`data`).
+
+- **`deserialize()`**
+
+    Arguments:
+
+    - `json`: A JSON representation of data.
+    - `options={}`: Deserialization options.
+        - `recordTypes={}`: `immutable.Record` factories.
+
+    Return value:
+
+    - `any`: Deserialized data.
+
+## Running Tests
+
+1. Clone the repository.
+2. `npm install`
+3. `npm test`

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,0 +1,42 @@
+const immutable = require('immutable')
+
+const { deserialize, serialize } = require('../')
+
+
+const RecordA = immutable.Record({
+  'a1': 3,
+  'a2': 4,
+  'b': null,
+}, 'RecordA')
+
+const RecordB = immutable.Record({
+  'b1': 5,
+  'b2': 6,
+  'c': null
+}, 'RecordB')
+
+
+let data = immutable.Map()
+data = data.set(1, new RecordA({
+  'b': immutable.List.of(
+    new RecordB({
+      'c': immutable.List()
+    })
+  )
+}))
+
+
+const json = serialize(data)
+console.log('data =', data)
+console.log('json =', json)
+console.log('---')
+
+
+const result = deserialize(json, {
+  recordTypes: {
+    'RecordA': RecordA,
+    'RecordB': RecordB,
+  },
+})
+console.log('result =', result)
+console.log('data   =', data)

--- a/package.json
+++ b/package.json
@@ -1,4 +1,20 @@
 {
   "name": "json-immutable",
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "main": "lib/index",
+  "scripts": {
+    "prepublish": "babel src/ -d lib/",
+    "test": "ava"
+  },
+  "peerDependencies": {
+    "immutable": "3.x.x"
+  },
+  "dependencies": {
+    "debug": "2.2.x"
+  },
+  "devDependencies": {
+    "ava": "0.16.x",
+    "babel-cli": "6.14.x",
+    "immutable": "3.8.x"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./json-immutable')

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -1,0 +1,158 @@
+const debug = require('debug')('json-immutable')
+const immutable = require('immutable')
+
+
+function deserialize(json, options = {}) {
+  return JSON.parse(json, (key, value) => {
+    return revive(key, value, options)
+  })
+}
+
+function serialize(data, options = {}) {
+  if (immutable.Iterable.isIterable(data) || data instanceof immutable.Record) {
+    // NOTE: JSON.stringify() calls the #toJSON() method of the root object.
+    //   Immutable.JS provides its own #toJSON() implementation which does not
+    //   preserve map key types.
+    data = Object.create(data)
+    data.toJSON = function () {
+      debug('#toJSON()', this)
+      return this
+    }
+  }
+
+  const indentation = options.pretty ? 2 : 0
+
+  return JSON.stringify(data, replace, indentation)
+}
+
+
+function revive(key, value, options) {
+  if (typeof value === 'object' && value) {
+    if (value['__record']) {
+      return reviveRecord(key, value, options)
+    } else if (value['__iterable']) {
+      return reviveIterable(key, value, options)
+    }
+  }
+  return value
+}
+
+function replace(key, value) {
+  debug('key:', key)
+  debug('value:', value)
+
+  let result = value
+
+  if (value instanceof immutable.Record) {
+    result = replaceRecord(value)
+  }
+  else if (immutable.Iterable.isIterable(value)) {
+    result = replaceIterable(value)
+  }
+  else if (Array.isArray(value)) {
+    result = replaceArray(value)
+  }
+  else if (typeof value === 'object' && value !== null) {
+    result = replacePlainObject(value)
+  }
+
+  debug('result:', result, '\n---')
+  return result
+}
+
+
+function reviveRecord(key, recInfo, options) {
+  const RecordType = options.recordTypes[recInfo['__record']]
+  if (!RecordType) {
+    throw new Error(`Unknown record type: ${recInfo['__record']}`)
+  }
+
+  return RecordType(revive(key, recInfo['data'], options))
+}
+
+function replaceRecord(rec) {
+  debug('replaceRecord()', rec)
+  const recordDataMap = rec.toMap()
+  const recordData = recordDataMap.map((value, key) => {
+    return replace(key, value)
+  })
+
+  if (!rec._name) {
+    return recordData.toObject()
+  }
+  return { "__record": rec._name, "data": recordData.toObject() }
+}
+
+
+function reviveIterable(key, iterInfo, options) {
+  switch (iterInfo['__iterable']) {
+  case 'List':
+    return immutable.List(revive(key, iterInfo['data'], options))
+
+  case 'Set':
+    return immutable.Set(revive(key, iterInfo['data'], options))
+
+  case 'OrderedSet':
+    return immutable.OrderedSet(revive(key, iterInfo['data'], options))
+
+  case 'Stack':
+    return immutable.Stack(revive(key, iterInfo['data'], options))
+
+  case 'Map':
+    return immutable.Map(revive(key, iterInfo['data'], options))
+
+  case 'OrderedMap':
+    return immutable.OrderedMap(revive(key, iterInfo['data'], options))
+
+  default:
+    throw new Error(`Unknown iterable type: ${iterInfo['__iterable']}`)
+  }
+}
+
+function replaceIterable(iter) {
+  debug('replaceIterable()', iter)
+  const iterableData = iter.map((value, key) => {
+    return replace(key, value)
+  })
+  const iterableType = iter.constructor.name
+
+  switch (iterableType) {
+  case 'List':
+  case 'Set':
+  case 'OrderedSet':
+  case 'Stack':
+    return { "__iterable": iterableType, "data": iterableData.toArray() }
+
+  case 'Map':
+  case 'OrderedMap':
+    const mapEntrySeq = iterableData.entrySeq()
+    return { "__iterable": iterableType, "data": mapEntrySeq.toArray() }
+
+  default:
+    return { "__iterable": iterableType, "data": iterableData.toObject() }
+  }
+}
+
+
+function replaceArray(arr) {
+  debug('replaceArray()', arr)
+
+  return arr.map((value, index) => {
+    return replace(index, value)
+  })
+}
+
+
+function replacePlainObject(obj) {
+  debug('replacePlainObject()', obj)
+
+  const objData = {}
+  Object.keys(obj).forEach((key) => {
+    objData[key] = replace(key, obj[key])
+  })
+
+  return objData
+}
+
+
+module.exports = { deserialize, serialize }

--- a/test/deserialize/_helpers.js
+++ b/test/deserialize/_helpers.js
@@ -1,0 +1,11 @@
+const { deserialize } = require('../../src/')
+
+
+exports.testDeserialization = function (test, data, expectedResult, options = {}) {
+  const result = exports.getDeserializationResult(data, options)
+  test.deepEqual(result, expectedResult)
+}
+
+exports.getDeserializationResult = function (data, options = {}) {
+  return deserialize(JSON.stringify(data), options)
+}

--- a/test/deserialize/iterable.js
+++ b/test/deserialize/iterable.js
@@ -1,0 +1,158 @@
+import immutable from 'immutable'
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+it('should deserialize an immutable.Map serialized as an array of entries',
+    (test) => {
+  const data = {
+    '__iterable': 'Map',
+    'data': [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.Map(data['data']))
+})
+
+
+it('should deserialize an immutable.Map serialized as a plain object',
+    (test) => {
+  const data = {
+    '__iterable': 'Map',
+    'data': {
+      'a': 5,
+      'b': 6,
+    },
+  }
+
+  helpers.testDeserialization(test, data, immutable.Map(data['data']))
+})
+
+
+it('should preserve key types of an immutable.Map', (test) => {
+  const data = {
+    '__iterable': 'Map',
+    'data': [
+      [ 5, 'a' ],
+      [ 6, 'b' ],
+    ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.Map(data['data']))
+})
+
+
+it('should deserialize an immutable.OrderedMap serialized as an array of entries',
+    (test) => {
+  const data = {
+    '__iterable': 'OrderedMap',
+    'data': [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.OrderedMap(data['data']))
+})
+
+
+it('should deserialize an immutable.OrderedMap serialized as a plain object',
+    (test) => {
+  const data = {
+    '__iterable': 'OrderedMap',
+    'data': {
+      'a': 5,
+      'b': 6,
+    },
+  }
+
+  helpers.testDeserialization(test, data, immutable.OrderedMap(data['data']))
+})
+
+
+it('should deserialize a record of a known type nested in an immutable.Map',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'b': 1,
+    'c': 2,
+  }, 'SampleRecord')
+
+
+  const data = {
+    '__iterable': 'Map',
+    'data': [
+      [ 'a', {
+        '__record': 'SampleRecord',
+        'data': {
+          'b': 5,
+          'c': 6,
+        }
+      } ],
+    ],
+  }
+
+  const expectedResult = immutable.Map({
+    'a': SampleRecord(data['data'][0][1]['data']),
+  })
+
+  helpers.testDeserialization(test, data, expectedResult, {
+    recordTypes: {
+      'SampleRecord': SampleRecord,
+    },
+  })
+})
+
+
+it('should deserialize an immutable.List', (test) => {
+  const data = {
+    '__iterable': 'List',
+    'data': [ 5, 6 ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.List(data['data']))
+})
+
+
+it('should deserialize an immutable.Set', (test) => {
+  const data = {
+    '__iterable': 'Set',
+    'data': [ 5, 6 ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.Set(data['data']))
+})
+
+
+it('should deserialize an immutable.OrderedSet', (test) => {
+  const data = {
+    '__iterable': 'OrderedSet',
+    'data': [ 5, 6 ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.OrderedSet(data['data']))
+})
+
+
+it('should deserialize an immutable.Stack', (test) => {
+  const data = {
+    '__iterable': 'Stack',
+    'data': [ 5, 6 ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.Stack(data['data']))
+})
+
+
+it('should not deserialize an iterable of an unknown type', (test) => {
+  const data = {
+    '__iterable': 'UnknownType',
+    'data': [ 5, 6 ],
+  }
+
+  test.throws(() => {
+    test.getDeserializationResult(data)
+  })
+})

--- a/test/deserialize/plain.js
+++ b/test/deserialize/plain.js
@@ -1,0 +1,49 @@
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+function testPlainDeserialization(test, data) {
+  return helpers.testDeserialization(test, data, data)
+}
+
+
+it('should deserialize a null value', (test) => {
+  testPlainDeserialization(test, null)
+})
+
+
+it('should deserialize a string value', (test) => {
+  testPlainDeserialization(test, 'string value')
+})
+
+
+it('should deserialize a numeric value', (test) => {
+  testPlainDeserialization(test, 123)
+})
+
+
+it('should deserialize a single-level plain object', (test) => {
+  testPlainDeserialization(test, {
+    'a': 5,
+    'b': 6,
+  })
+})
+
+
+it('should deserialize a nested plain object', (test) => {
+  testPlainDeserialization(test, {
+    'a': 5,
+    'b': {
+      'c': 6,
+    },
+  })
+})
+
+
+it('should deserialize an array nested in a plain object', (test) => {
+  testPlainDeserialization(test, {
+    'a': [ 'b', 123 ],
+  })
+})
+

--- a/test/deserialize/record.js
+++ b/test/deserialize/record.js
@@ -1,0 +1,79 @@
+import immutable from 'immutable'
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+it('should deserialize a record of a known type', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 1,
+    'b': 2,
+  }, 'SampleRecord')
+
+  const data = {
+    '__record': 'SampleRecord',
+    'data': {
+      'a': 5,
+      'b': 6,
+    },
+  }
+
+  helpers.testDeserialization(test, data, SampleRecord(data['data']), {
+    recordTypes: {
+      'SampleRecord': SampleRecord,
+    },
+  })
+})
+
+
+it('should not deserialize a record of an unknown type', (test) => {
+  const data = {
+    '__record': 'SampleRecord',
+    'data': {
+      'a': 5,
+      'b': 6,
+    },
+  }
+
+  test.throws(() => {
+    helpers.getDeserializationResult(data, {
+      recordTypes: {},
+    })
+  })
+})
+
+
+it('should deserialize nested records of known types', (test) => {
+  const RecordA = immutable.Record({
+    'a': 1,
+    'b': 2,
+  }, 'RecordA')
+  const RecordB = immutable.Record({
+    'c': 3,
+  }, 'RecordB')
+
+  const data = {
+    '__record': 'RecordA',
+    'data': {
+      'a': 5,
+      'b': {
+        '__record': 'RecordB',
+        'data': {
+          'c': 6,
+        },
+      },
+    },
+  }
+
+  const expectedResult = RecordA({
+    'a': data['data']['a'],
+    'b': RecordB(data['data']['b']['data']),
+  })
+
+  helpers.testDeserialization(test, data, expectedResult, {
+    recordTypes: {
+      'RecordA': RecordA,
+      'RecordB': RecordB,
+    },
+  })
+})

--- a/test/serialize/_helpers.js
+++ b/test/serialize/_helpers.js
@@ -1,0 +1,12 @@
+const { serialize } = require('../../src/')
+
+
+exports.testSerialization = function (test, data, expectedResult) {
+  const result = exports.getSerializationResult(data)
+  test.deepEqual(result, expectedResult)
+}
+
+exports.getSerializationResult = function (data) {
+  const json = serialize(data)
+  return JSON.parse(json)
+}

--- a/test/serialize/iterable.js
+++ b/test/serialize/iterable.js
@@ -1,0 +1,191 @@
+import immutable from 'immutable'
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+
+it('should mark an immutable.Map as __iterable=Map', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationResult(data)
+  test.is(result['__iterable'], 'Map')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an immutable.Map as an array of entries', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [
+    [ 'a', 5 ],
+    [ 'b', 6 ],
+  ])
+})
+
+
+it('should serialize a nested immutable.Map as a nested array of entries',
+    (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': immutable.Map({
+      'c': 6,
+    }),
+  })
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [
+    [ 'a', 5 ],
+    [ 'b', {
+      '__iterable': 'Map',
+      'data': [
+        [ 'c', 6 ],
+      ],
+    } ],
+  ])
+})
+
+
+it('should serialize an immutable.Map nested in a plain object', (test) => {
+  const data = {
+    'x': immutable.Map({
+      'a': 5,
+      'b': 6,
+    }),
+  }
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['x']['data'], [
+    [ 'a', 5 ],
+    [ 'b', 6 ],
+  ])
+})
+
+
+it('should preserve immutable.Map key types', (test) => {
+  let data = immutable.Map()
+  data = data.set(5, 'a')
+  data = data.set(6, 'b')
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [
+    [ 5, 'a' ],
+    [ 6, 'b' ],
+  ])
+})
+
+
+it('should mark an immutable.OrderedMap as __iterable=OrderedMap', (test) => {
+  const data = immutable.OrderedMap({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationResult(data)
+  test.is(result['__iterable'], 'OrderedMap')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an immutable.OrderedMap as an array of entries', (test) => {
+  const data = immutable.OrderedMap({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [
+    [ 'a', 5 ],
+    [ 'b', 6 ],
+  ])
+})
+
+
+it('should serialize an immutable.Map as an array of entries', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [
+    [ 'a', 5 ],
+    [ 'b', 6 ],
+  ])
+})
+
+
+it('should mark an immutable.List as __iterable=List', (test) => {
+  const data = immutable.List.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.is(result['__iterable'], 'List')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an immutable.List as an array of values', (test) => {
+  const data = immutable.List.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [ 5, 6 ])
+})
+
+
+it('should mark an immutable.Set as __iterable=Set', (test) => {
+  const data = immutable.Set.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.is(result['__iterable'], 'Set')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an immutable.Set as an array of values', (test) => {
+  const data = immutable.Set.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [ 5, 6 ])
+})
+
+
+it('should mark an immutable.OrderedSet as __iterable=OrderedSet', (test) => {
+  const data = immutable.OrderedSet.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.is(result['__iterable'], 'OrderedSet')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an immutable.OrderedSet as an array of values', (test) => {
+  const data = immutable.OrderedSet.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [ 5, 6 ])
+})
+
+
+it('should mark an immutable.Stack as __iterable=Stack', (test) => {
+  const data = immutable.Stack.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.is(result['__iterable'], 'Stack')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an immutable.Stack as an array of values', (test) => {
+  const data = immutable.Stack.of(5, 6)
+
+  const result = helpers.getSerializationResult(data)
+  test.deepEqual(result['data'], [ 5, 6 ])
+})
+

--- a/test/serialize/plain.js
+++ b/test/serialize/plain.js
@@ -1,0 +1,50 @@
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+function testPlainSerialization(test, data) {
+  return helpers.testSerialization(test, data, data)
+}
+
+
+
+it('should serialize a null value', (test) => {
+  testPlainSerialization(test, null)
+})
+
+
+it('should serialize a string value', (test) => {
+  testPlainSerialization(test, 'string value')
+})
+
+
+it('should serialize a numeric value', (test) => {
+  testPlainSerialization(test, 123)
+})
+
+
+it('should serialize a single-level plain object', (test) => {
+  testPlainSerialization(test, {
+    'a': 5,
+    'b': 6,
+  })
+})
+
+
+it('should serialize a nested plain object', (test) => {
+  testPlainSerialization(test, {
+    'a': {
+      'b': {
+        'c': 123,
+      },
+    },
+  })
+})
+
+
+it('should serialize an array nested in a plain object', (test) => {
+  testPlainSerialization(test, {
+    'a': [ 'b', 123 ],
+  })
+})

--- a/test/serialize/record.js
+++ b/test/serialize/record.js
@@ -1,0 +1,129 @@
+import immutable from 'immutable'
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+
+it('should not mark an unnamed immutable.Record as __record', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationResult(data)
+
+  test.falsy(result['__record'])
+})
+
+
+it('should mark a named immutable.Record as __record=<name>', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  }, 'SampleRecord')
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationResult(data)
+
+  test.is(result['__record'], 'SampleRecord')
+  test.truthy(result['data'])
+})
+
+
+it('should serialize an unnamed immutable.Record as a plain object',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  })
+
+  const data = SampleRecord()
+
+  helpers.testSerialization(test, data, {
+    'a': 5,
+    'b': 6,
+  })
+})
+
+
+it('should serialize a named immutable.Record data as a plain object',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  }, 'SampleRecord')
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationResult(data)
+
+  test.deepEqual(result['data'], {
+    'a': 5,
+    'b': 6,
+  })
+})
+
+
+it('should serialize nested plain objects in immutable.Record data',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'a': { 'x': 5 },
+    'b': { 'y': 6, 'z': 7 },
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationResult(data)
+
+  test.deepEqual(result, {
+    'a': { 'x': 5 },
+    'b': { 'y': 6, 'z': 7 },
+  })
+})
+
+
+it('should serialize an immutable.Map in immutable.Record data', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': immutable.Map({ 'x': 5 }),
+    'b': immutable.Map({ 'y': 6, 'z': 7 },)
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationResult(data)
+
+  test.deepEqual(result, {
+    'a': {
+      '__iterable': 'Map',
+      'data': [
+        [ 'x', 5 ],
+      ],
+    },
+    'b': {
+      '__iterable': 'Map',
+      'data': [
+        [ 'y', 6 ],
+        [ 'z', 7 ],
+      ],
+    },
+  })
+})
+
+
+it('should preserve key types of an immutable.Map in immutable.Record data',
+    (test) => {
+  let typedKeyedMap = immutable.Map()
+  typedKeyedMap = typedKeyedMap.set(123, 'a')
+  typedKeyedMap = typedKeyedMap.set(true, 'b')
+
+  const SampleRecord = immutable.Record({
+    'a': typedKeyedMap
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationResult(data)
+
+  test.deepEqual(result['a']['data'], [
+    [ 123, 'a' ],
+    [ true, 'b' ],
+  ])
+})


### PR DESCRIPTION
## Motivation

By using the native `JSON` API, Immutable.JS structures are serialized as plain objects and arrays with no type information. The goal was to preserve both Immutable.JS `Iterable` types (maps, lists, etc.) and `Record` types. `immutable.Map` supports and preserves key types while plain JavaScript object keys are coerced to strings. These types should also preserved.
## Usage
### Plain Objects and Primitive Types

``` javascript
const data = { 'a': 'b', 'c': 123, 'd': true }

// Serialize
const json = serialize(data)
// json == '{"a":"b","c":123,"d":true}'

// Deserialize
const result = deserialize(json)
```
### Immutable Records

``` javascript
const SampleRecord = immutable.Record(
  { 'a': 3, 'b': 4 },
  'SampleRecord'
)

const data = {
  'x': SampleRecord({ 'a': 5 }),
}

// Serialize
const json = serialize(data)
// json == '{"x":{"__record":"SampleRecord","data":{"a":5}}}'

// Deserialize
const result = deserialize(json, {
  recordTypes: {
    'SampleRecord': SampleRecord
  }
})
```

Record types can be named. This is utilized by the serializer/deserializer to revive `immutable.Record` objects. See the `SampleRecord` name passed into `immutable.Record()` as the second argument.

NOTE: When an unknown record type is encountered during deserialization, an error is thrown.
### General Immutable Structures

``` javascript
const data = {
  'x': immutable.Map({
    'y': immutable.List.of(1, 2, 3)
  }),
}

// Serialization
const json = serialize(data)
// json == '{"x":{"__iterable":"Map","data":[["y",{"__iterable":"List","data":[1,2,3]"}]]}}'

// Deserialize
const result = deserialize(json)
```
- Immutable structures, plain objects and primitive data can be safely composed together.
- `immutable.Map` key type information is preserved as opposed to the bare `JSON` API.

NOTE: When an unknown Immutable iterable type is encountered during deserialization, an error is thrown. The supported types are `List`, `Map`, `OrderedMap`, `Set`, `OrderedSet` and `Stack`.
## API
- **`serialize()`**
  
  Arguments:
  - `data`: The data to serialize.
  - `options={}`: Serialization options.
    - `pretty=false`: Whether to pretty-print the result (2 spaces).
  
  Return value:
  - `string`: The JSON representation of the input (`data`).
- **`deserialize()`**
  
  Arguments:
  - `json`: A JSON representation of data.
  - `options={}`: Deserialization options.
    - `recordTypes={}`: `immutable.Record` factories.
  
  Return value:
  - `any`: Deserialized data.
