### PR TITLE
Asynchronous Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
 
     - `data`: The data to serialize.
     - `options={}`: Serialization options.
+        - `pretty=false`: Whether to pretty-print the result (2 spaces).
         - `bigChunks=false`: Whether the serialized data should only be split into chunks based on the reader speed. By default, each data structure level is processed in its own event loop microtask which.
             - NOTE: When `bigChunks=true`, a (possibly substantial) portion of the data is serialized synchronously.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
 
     - `any`: Deserialized data.
 
+### Streaming API
+
+- **`createSerializationStream()`**
+
+    Arguments:
+
+    - `data`: The data to serialize.
+
+    Return value:
+
+    - `stream.PassThrough<!Buffer>`: A readable stream emitting the JSON representation of the input (`data`).
+
 ## Running Tests
 
 1. Clone the repository.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
     Arguments:
 
     - `data`: The data to serialize.
+    - `options={}`: Serialization options.
+        - `bigChunks=false`: Whether the serialized data should only be split into chunks based on the reader speed. By default, each data structure level is processed in its own event loop microtask which.
+            - NOTE: When `bigChunks=true`, a (possibly substantial) portion of the data is serialized synchronously.
 
     Return value:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-immutable",
-  "version": "0.1.0",
+  "version": "0.2.0-0",
   "main": "lib/index",
   "scripts": {
     "prepublish": "babel src/ -d lib/",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "immutable": "3.x.x"
   },
   "dependencies": {
-    "debug": "2.2.x"
+    "debug": "2.2.x",
+    "json-stream-stringify": "1.5.x"
   },
   "devDependencies": {
     "ava": "0.16.x",

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -29,9 +29,10 @@ function serialize(data, options = {}) {
 
 
 function createSerializationStream(data, options = {}) {
+  const indentation = options.pretty ? 2 : 0
   const replacer = options.bigChunks ? replace : replaceAsync
 
-  const stream = JSONStreamStringify(data, replacer)
+  const stream = JSONStreamStringify(data, replacer, indentation)
   return stream
 }
 

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -29,7 +29,9 @@ function serialize(data, options = {}) {
 
 
 function createSerializationStream(data, options = {}) {
-  const stream = JSONStreamStringify(data, replaceAsync)
+  const replacer = options.bigChunks ? replace : replaceAsync
+
+  const stream = JSONStreamStringify(data, replacer)
   return stream
 }
 

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -52,16 +52,16 @@ function replace(key, value) {
   let result = value
 
   if (value instanceof immutable.Record) {
-    result = replaceRecord(value)
+    result = replaceRecord(value, replace)
   }
   else if (immutable.Iterable.isIterable(value)) {
-    result = replaceIterable(value)
+    result = replaceIterable(value, replace)
   }
   else if (Array.isArray(value)) {
-    result = replaceArray(value)
+    result = replaceArray(value, replace)
   }
   else if (typeof value === 'object' && value !== null) {
-    result = replacePlainObject(value)
+    result = replacePlainObject(value, replace)
   }
 
   debug('result:', result, '\n---')
@@ -78,11 +78,11 @@ function reviveRecord(key, recInfo, options) {
   return RecordType(revive(key, recInfo['data'], options))
 }
 
-function replaceRecord(rec) {
+function replaceRecord(rec, replaceChild) {
   debug('replaceRecord()', rec)
   const recordDataMap = rec.toMap()
   const recordData = recordDataMap.map((value, key) => {
-    return replace(key, value)
+    return replaceChild(key, value)
   })
 
   if (!rec._name) {
@@ -117,10 +117,10 @@ function reviveIterable(key, iterInfo, options) {
   }
 }
 
-function replaceIterable(iter) {
+function replaceIterable(iter, replaceChild) {
   debug('replaceIterable()', iter)
   const iterableData = iter.map((value, key) => {
-    return replace(key, value)
+    return replaceChild(key, value)
   })
   const iterableType = iter.constructor.name
 
@@ -142,21 +142,21 @@ function replaceIterable(iter) {
 }
 
 
-function replaceArray(arr) {
+function replaceArray(arr, replaceChild) {
   debug('replaceArray()', arr)
 
   return arr.map((value, index) => {
-    return replace(index, value)
+    return replaceChild(index, value)
   })
 }
 
 
-function replacePlainObject(obj) {
+function replacePlainObject(obj, replaceChild) {
   debug('replacePlainObject()', obj)
 
   const objData = {}
   Object.keys(obj).forEach((key) => {
-    objData[key] = replace(key, obj[key])
+    objData[key] = replaceChild(key, obj[key])
   })
 
   return objData

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -29,7 +29,7 @@ function serialize(data, options = {}) {
 
 
 function createSerializationStream(data, options = {}) {
-  const stream = JSONStreamStringify(data, replace)
+  const stream = JSONStreamStringify(data, replaceAsync)
   return stream
 }
 
@@ -62,6 +62,47 @@ function replace(key, value) {
   }
   else if (typeof value === 'object' && value !== null) {
     result = replacePlainObject(value, replace)
+  }
+
+  debug('result:', result, '\n---')
+  return result
+}
+
+function replaceAsync(key, value) {
+  debug('key:', key)
+  debug('value:', value)
+
+  let result = value
+
+  if (!(value instanceof Promise)) {
+    if (value instanceof immutable.Record) {
+      result = new Promise((resolve) => {
+        setImmediate(() => {
+          resolve(replaceRecord(value, replaceAsync))
+        })
+      })
+    }
+    else if (immutable.Iterable.isIterable(value)) {
+      result = new Promise((resolve) => {
+        setImmediate(() => {
+          resolve(replaceIterable(value, replaceAsync))
+        })
+      })
+    }
+    else if (Array.isArray(value)) {
+      result = new Promise((resolve) => {
+        setImmediate(() => {
+          resolve(replaceArray(value, replaceAsync))
+        })
+      })
+    }
+    else if (typeof value === 'object' && value !== null) {
+      result = new Promise((resolve) => {
+        setImmediate(() => {
+          resolve(replacePlainObject(value, replaceAsync))
+        })
+      })
+    }
   }
 
   debug('result:', result, '\n---')

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -125,14 +125,16 @@ function reviveRecord(key, recInfo, options) {
 function replaceRecord(rec, replaceChild) {
   debug('replaceRecord()', rec)
   const recordDataMap = rec.toMap()
-  const recordData = recordDataMap.map((value, key) => {
-    return replaceChild(key, value)
+  const recordData = {}
+
+  recordDataMap.forEach((value, key) => {
+    recordData[key] = replaceChild(key, value)
   })
 
   if (!rec._name) {
-    return recordData.toObject()
+    return recordData
   }
-  return { "__record": rec._name, "data": recordData.toObject() }
+  return { "__record": rec._name, "data": recordData }
 }
 
 
@@ -163,25 +165,33 @@ function reviveIterable(key, iterInfo, options) {
 
 function replaceIterable(iter, replaceChild) {
   debug('replaceIterable()', iter)
-  const iterableData = iter.map((value, key) => {
-    return replaceChild(key, value)
-  })
-  const iterableType = iter.constructor.name
 
+  const iterableType = iter.constructor.name
   switch (iterableType) {
   case 'List':
   case 'Set':
   case 'OrderedSet':
   case 'Stack':
-    return { "__iterable": iterableType, "data": iterableData.toArray() }
+    const listData = []
+    iter.forEach((value, key) => {
+      listData.push(replaceChild(key, value))
+    })
+    return { "__iterable": iterableType, "data": listData }
 
   case 'Map':
   case 'OrderedMap':
-    const mapEntrySeq = iterableData.entrySeq()
-    return { "__iterable": iterableType, "data": mapEntrySeq.toArray() }
+    const mapData = []
+    iter.forEach((value, key) => {
+      mapData.push([ key, replaceChild(key, value) ])
+    })
+    return { "__iterable": iterableType, "data": mapData }
 
   default:
-    return { "__iterable": iterableType, "data": iterableData.toObject() }
+    const iterData = {}
+    iter.forEach((value, key) => {
+      iterData[key] = replaceChild(key, value)
+    })
+    return { "__iterable": iterableType, "data": iterData }
   }
 }
 

--- a/src/json-immutable.js
+++ b/src/json-immutable.js
@@ -1,6 +1,8 @@
 const debug = require('debug')('json-immutable')
 const immutable = require('immutable')
 
+const JSONStreamStringify = require('json-stream-stringify')
+
 
 function deserialize(json, options = {}) {
   return JSON.parse(json, (key, value) => {
@@ -23,6 +25,12 @@ function serialize(data, options = {}) {
   const indentation = options.pretty ? 2 : 0
 
   return JSON.stringify(data, replace, indentation)
+}
+
+
+function createSerializationStream(data, options = {}) {
+  const stream = JSONStreamStringify(data, replace)
+  return stream
 }
 
 
@@ -155,4 +163,8 @@ function replacePlainObject(obj) {
 }
 
 
-module.exports = { deserialize, serialize }
+module.exports = {
+  createSerializationStream,
+  deserialize,
+  serialize
+}

--- a/test/create-serialization-stream/_helpers.js
+++ b/test/create-serialization-stream/_helpers.js
@@ -1,23 +1,54 @@
+const assert = require('assert')
+
 const JsonImmutable = require('../../lib/')
 
 
 exports.testSerializationStream = function (test, data, expectedResult) {
-  const result = exports.getSerializationStreamResult(data)
-  return result.then((result) => {
-    test.deepEqual(result, expectedResult)
+  const littleChunkedData = getSerializationStreamDataWithOptions(data, {})
+  const bigChunkedData = getSerializationStreamDataWithOptions(data, {
+    bigChunks: true,
+  })
+
+  return littleChunkedData.then((littleChunkedData) => {
+    return bigChunkedData.then((bigChunkedData) => {
+      assert.equal(
+        littleChunkedData,
+        bigChunkedData,
+        'Little-chunked and big-chunked serialization results do not match.'
+      )
+      test.deepEqual(JSON.parse(littleChunkedData), expectedResult)
+    })
   })
 }
 
-exports.getSerializationStreamResult = function (data) {
+exports.getSerializationStreamResult = function (data, options) {
+  const littleChunkedData = getSerializationStreamDataWithOptions(data, {})
+  const bigChunkedData = getSerializationStreamDataWithOptions(data, {
+    bigChunks: true,
+  })
+
+  return littleChunkedData.then((littleChunkedData) => {
+    return bigChunkedData.then((bigChunkedData) => {
+      assert.equal(
+        littleChunkedData,
+        bigChunkedData,
+        'Little-chunked and big-chunked serialization results do not match.'
+      )
+      return JSON.parse(littleChunkedData)
+    })
+  })
+}
+
+function getSerializationStreamDataWithOptions(data, options) {
   return new Promise((resolve) => {
-    const jsonStream = JsonImmutable.createSerializationStream(data)
+    const jsonStream = JsonImmutable.createSerializationStream(data, options)
     const jsonChunks = []
     jsonStream.on('data', (chunk) => {
       jsonChunks.push(chunk)
     })
     jsonStream.on('end', () => {
       const json = jsonChunks.join('')
-      resolve(JSON.parse(json))
+      resolve(json)
     })
   })
 }

--- a/test/create-serialization-stream/_helpers.js
+++ b/test/create-serialization-stream/_helpers.js
@@ -1,0 +1,23 @@
+const JsonImmutable = require('../../lib/')
+
+
+exports.testSerializationStream = function (test, data, expectedResult) {
+  const result = exports.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result, expectedResult)
+  })
+}
+
+exports.getSerializationStreamResult = function (data) {
+  return new Promise((resolve) => {
+    const jsonStream = JsonImmutable.createSerializationStream(data)
+    const jsonChunks = []
+    jsonStream.on('data', (chunk) => {
+      jsonChunks.push(chunk)
+    })
+    jsonStream.on('end', () => {
+      const json = jsonChunks.join('')
+      resolve(JSON.parse(json))
+    })
+  })
+}

--- a/test/create-serialization-stream/iterable.js
+++ b/test/create-serialization-stream/iterable.js
@@ -1,0 +1,238 @@
+import immutable from 'immutable'
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+it('should mark an immutable.Map as __iterable=Map', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__iterable'], 'Map')
+    test.truthy(result['data'])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.Map as an array of entries', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ])
+    test.pass()
+  })
+})
+
+
+it('should serialize a nested immutable.Map as a nested array of entries',
+    (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': immutable.Map({
+      'c': 6,
+    }),
+  })
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [
+      [ 'a', 5 ],
+      [ 'b', {
+        '__iterable': 'Map',
+        'data': [
+          [ 'c', 6 ],
+        ],
+      } ],
+    ])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.Map nested in a plain object', (test) => {
+  const data = {
+    'x': immutable.Map({
+      'a': 5,
+      'b': 6,
+    }),
+  }
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+      test.deepEqual(result['x']['data'], [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ])
+      test.pass()
+  })
+})
+
+
+it('should preserve immutable.Map key types', (test) => {
+  let data = immutable.Map()
+  data = data.set(5, 'a')
+  data = data.set(6, 'b')
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [
+      [ 5, 'a' ],
+      [ 6, 'b' ],
+    ])
+    test.pass()
+  })
+})
+
+
+it('should mark an immutable.OrderedMap as __iterable=OrderedMap', (test) => {
+  const data = immutable.OrderedMap({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__iterable'], 'OrderedMap')
+    test.truthy(result['data'])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.OrderedMap as an array of entries', (test) => {
+  const data = immutable.OrderedMap({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.Map as an array of entries', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ])
+    test.pass()
+  })
+})
+
+
+it('should mark an immutable.List as __iterable=List', (test) => {
+  const data = immutable.List.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__iterable'], 'List')
+    test.truthy(result['data'])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.List as an array of values', (test) => {
+  const data = immutable.List.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [ 5, 6 ])
+    test.pass()
+  })
+})
+
+
+it('should mark an immutable.Set as __iterable=Set', (test) => {
+  const data = immutable.Set.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__iterable'], 'Set')
+    test.truthy(result['data'])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.Set as an array of values', (test) => {
+  const data = immutable.Set.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [ 5, 6 ])
+    test.pass()
+  })
+})
+
+
+it('should mark an immutable.OrderedSet as __iterable=OrderedSet', (test) => {
+  const data = immutable.OrderedSet.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__iterable'], 'OrderedSet')
+    test.truthy(result['data'])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.OrderedSet as an array of values', (test) => {
+  const data = immutable.OrderedSet.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [ 5, 6 ])
+    test.pass()
+  })
+})
+
+
+it('should mark an immutable.Stack as __iterable=Stack', (test) => {
+  const data = immutable.Stack.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__iterable'], 'Stack')
+    test.truthy(result['data'])
+    test.pass()
+  })
+})
+
+
+it('should serialize an immutable.Stack as an array of values', (test) => {
+  const data = immutable.Stack.of(5, 6)
+
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], [ 5, 6 ])
+    test.pass()
+  })
+})
+

--- a/test/create-serialization-stream/plain.js
+++ b/test/create-serialization-stream/plain.js
@@ -1,0 +1,50 @@
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+function testPlainSerializationStream(test, data) {
+  return helpers.testSerializationStream(test, data, data)
+}
+
+
+
+it('should serialize a null value', (test) => {
+  return testPlainSerializationStream(test, null)
+})
+
+
+it('should serialize a string value', (test) => {
+  return testPlainSerializationStream(test, 'string value')
+})
+
+
+it('should serialize a numeric value', (test) => {
+  return testPlainSerializationStream(test, 123)
+})
+
+
+it('should serialize a single-level plain object', (test) => {
+  return testPlainSerializationStream(test, {
+    'a': 5,
+    'b': 6,
+  })
+})
+
+
+it('should serialize a nested plain object', (test) => {
+  return testPlainSerializationStream(test, {
+    'a': {
+      'b': {
+        'c': 123,
+      },
+    },
+  })
+})
+
+
+it('should serialize an array nested in a plain object', (test) => {
+  return testPlainSerializationStream(test, {
+    'a': [ 'b', 123 ],
+  })
+})

--- a/test/create-serialization-stream/record.js
+++ b/test/create-serialization-stream/record.js
@@ -1,0 +1,135 @@
+import immutable from 'immutable'
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+
+it('should not mark an unnamed immutable.Record as __record', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.falsy(result['__record'])
+  })
+})
+
+
+it('should mark a named immutable.Record as __record=<name>', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  }, 'SampleRecord')
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.is(result['__record'], 'SampleRecord')
+    test.truthy(result['data'])
+  })
+})
+
+
+it('should serialize an unnamed immutable.Record as a plain object',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  })
+
+  const data = SampleRecord()
+
+  return helpers.testSerializationStream(test, data, {
+    'a': 5,
+    'b': 6,
+  })
+})
+
+
+it('should serialize a named immutable.Record data as a plain object',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  }, 'SampleRecord')
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['data'], {
+      'a': 5,
+      'b': 6,
+    })
+  })
+})
+
+
+it('should serialize nested plain objects in immutable.Record data',
+    (test) => {
+  const SampleRecord = immutable.Record({
+    'a': { 'x': 5 },
+    'b': { 'y': 6, 'z': 7 },
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result, {
+      'a': { 'x': 5 },
+      'b': { 'y': 6, 'z': 7 },
+    })
+  })
+})
+
+
+it('should serialize an immutable.Map in immutable.Record data', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': immutable.Map({ 'x': 5 }),
+    'b': immutable.Map({ 'y': 6, 'z': 7 },)
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result, {
+      'a': {
+        '__iterable': 'Map',
+        'data': [
+          [ 'x', 5 ],
+        ],
+      },
+      'b': {
+        '__iterable': 'Map',
+        'data': [
+          [ 'y', 6 ],
+          [ 'z', 7 ],
+        ],
+      },
+    })
+  })
+})
+
+
+it('should preserve key types of an immutable.Map in immutable.Record data',
+    (test) => {
+  let typedKeyedMap = immutable.Map()
+  typedKeyedMap = typedKeyedMap.set(123, 'a')
+  typedKeyedMap = typedKeyedMap.set(true, 'b')
+
+  const SampleRecord = immutable.Record({
+    'a': typedKeyedMap
+  })
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data)
+  return result.then((result) => {
+    test.deepEqual(result['a']['data'], [
+      [ 123, 'a' ],
+      [ true, 'b' ],
+    ])
+  })
+})


### PR DESCRIPTION
## Usage

``` javascript
const jsonStream = JsonImmutable.createSerializationStream(data)
jsonStream.pipe(fs.createWriteStream('/path/to/file.json'))
```
## Documentation
### Streaming API
- **`createSerializationStream()`**
  
  Arguments:
  - `data`: The data to serialize.
  - `options={}`: Serialization options.
    - `pretty=false`: Whether to pretty-print the result (2 spaces).
    - `bigChunks=false`: Whether the serialized data should only be split into chunks based on the reader speed. By default, each data structure level is processed in its own event loop microtask which.
      - NOTE: When `bigChunks=true`, a (possibly substantial) portion of the data is serialized synchronously.
  
  Return value:
  - `stream.PassThrough<!Buffer>`: A readable stream emitting the JSON representation of the input (`data`).
