### PR TITLE
Native Type Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ const json = serialize(data)
 const result = deserialize(json)
 ```
 
+### Native Object Types
+
+```javascript
+const data = { 'created_at': new Date('2016-09-08'), 'pattern': /iamnative/g }
+
+// Serialize
+const json = serialize(data)
+// json == '{"created_at":{"__date":"2016-09-08T00:00:00Z"},"pattern":{"__regexp":"/iamnative/g"}}'
+
+// Deserialize
+const result = deserialize(json)
+```
+
 ### Immutable Records
 
 ```javascript

--- a/src/deserialize.js
+++ b/src/deserialize.js
@@ -15,6 +15,11 @@ function revive(key, value, options) {
       return reviveRecord(key, value, options)
     } else if (value['__iterable']) {
       return reviveIterable(key, value, options)
+    } else if (value['__date']) {
+      return new Date(value['__date'])
+    } else if (value['__regexp']) {
+      const regExpParts = value['__regexp'].split('/')
+      return new RegExp(regExpParts[1], regExpParts[2])
     }
   }
   return value

--- a/src/helpers/native-type-helpers.js
+++ b/src/helpers/native-type-helpers.js
@@ -1,0 +1,43 @@
+
+function getObjectType(value) {
+  if (!value) {
+    return null
+  }
+
+  return value.constructor.name
+}
+
+
+function isSupportedNativeType(value) {
+  return (
+    isDate(value) ||
+    isRegExp(value)
+  )
+}
+
+
+function isDate(value) {
+  return (getObjectType(value) === 'Date')
+}
+
+
+function isRegExp(value) {
+  return (getObjectType(value) === 'RegExp')
+}
+
+
+function patchNativeTypeMethods(patchedObj, nativeObj) {
+  patchedObj.toString = nativeObj.toString.bind(nativeObj)
+  if (isDate(nativeObj)) {
+    patchedObj.toISOString = nativeObj.toISOString.bind(nativeObj)
+  }
+}
+
+
+module.exports = {
+  getObjectType,
+  isSupportedNativeType,
+  isDate,
+  isRegExp,
+  patchNativeTypeMethods,
+}

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -6,14 +6,17 @@ const JSONStreamStringify = require('json-stream-stringify')
 
 function serialize(data, options = {}) {
   if (immutable.Iterable.isIterable(data) || data instanceof immutable.Record) {
+    const patchedData = Object.create(data)
+
     // NOTE: JSON.stringify() calls the #toJSON() method of the root object.
     //   Immutable.JS provides its own #toJSON() implementation which does not
     //   preserve map key types.
-    data = Object.create(data)
-    data.toJSON = function () {
+    patchedData.toJSON = function () {
       debug('#toJSON()', this)
       return this
     }
+
+    data = patchedData
   }
 
   const indentation = options.pretty ? 2 : 0

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -3,10 +3,23 @@ const immutable = require('immutable')
 
 const JSONStreamStringify = require('json-stream-stringify')
 
+const nativeTypeHelpers = require('./helpers/native-type-helpers')
+
 
 function serialize(data, options = {}) {
-  if (immutable.Iterable.isIterable(data) || data instanceof immutable.Record) {
+  if (immutable.Iterable.isIterable(data) ||
+      data instanceof immutable.Record ||
+      nativeTypeHelpers.isSupportedNativeType(data)
+  ) {
     const patchedData = Object.create(data)
+
+    if (nativeTypeHelpers.isSupportedNativeType(data)) {
+      // NOTE: When native type (such as Date or RegExp) methods are called
+      //   on an `Object.create()`'d objects, invalid usage errors are thrown
+      //   in many cases. We need to patch the used methods to work
+      //   on originals.
+      nativeTypeHelpers.patchNativeTypeMethods(patchedData, data)
+    }
 
     // NOTE: JSON.stringify() calls the #toJSON() method of the root object.
     //   Immutable.JS provides its own #toJSON() implementation which does not
@@ -48,6 +61,12 @@ function replace(key, value) {
   }
   else if (Array.isArray(value)) {
     result = replaceArray(value, replace)
+  }
+  else if (nativeTypeHelpers.isDate(value)) {
+    result = { '__date': value.toISOString() }
+  }
+  else if (nativeTypeHelpers.isRegExp(value)) {
+    result = { '__regexp': value.toString() }
   }
   else if (typeof value === 'object' && value !== null) {
     result = replacePlainObject(value, replace)

--- a/test/deserialize/native-objects.js
+++ b/test/deserialize/native-objects.js
@@ -1,0 +1,25 @@
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+
+it('should deserialize a Date object', (test) => {
+  const data = { '__date': '2016-09-08T00:01:02Z' }
+
+  helpers.testDeserialization(test, data, new Date(data['__date']))
+})
+
+
+it('should deserialize a RegExp object', (test) => {
+  const data = { '__regexp': '/(what)?\\w+$/' }
+
+  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$'))
+})
+
+
+it('should deserialize a RegExp object with flags', (test) => {
+  const data = { '__regexp': '/(what)?\\w+$/ig' }
+
+  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$', 'ig'))
+})

--- a/test/serialize/native-objects.js
+++ b/test/serialize/native-objects.js
@@ -1,0 +1,28 @@
+import it from 'ava'
+
+import helpers from './_helpers'
+
+
+
+it('should serialize a Date object', (test) => {
+  const date = new Date('2016-09-08')
+  const result = helpers.getSerializationResult(date)
+
+  test.is(result['__date'], date.toISOString())
+})
+
+
+it('should serialize a RegExp object', (test) => {
+  const regexp = new RegExp('(what)?\\w+$')
+  const result = helpers.getSerializationResult(regexp)
+
+  test.is(result['__regexp'], regexp.toString())
+})
+
+
+it('should serialize a RegExp object with flags', (test) => {
+  const regexp = new RegExp('(what)?\\w+$', 'ig')
+  const result = helpers.getSerializationResult(regexp)
+
+  test.is(result['__regexp'], regexp.toString())
+})


### PR DESCRIPTION
Adds support for `Date` and `RegExp` object serialization/deserialization.

---
### Native Object Types

``` javascript
const data = { 'created_at': new Date('2016-09-08'), 'pattern': /iamnative/g }

// Serialize
const json = serialize(data)
// json == '{"created_at":{"__date":"2016-09-08T00:00:00Z"},"pattern":{"__regexp":"/iamnative/g"}}'

// Deserialize
const result = deserialize(json)
```

---

Closes #4 
