### PR TITLE
fix vulnerability by upgrading debug 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "immutable": "3.x.x"
   },
   "dependencies": {
-    "debug": "2.2.x",
+    "debug": "^3.1.0",
     "json-stream-stringify": "1.5.x"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,11 +1118,17 @@ date-time@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-0.1.1.tgz#ed2f6d93d9790ce2fd66d5b5ff3edd5bbcbf3b07"
 
-debug@2.2.x, debug@^2.1.1, debug@^2.2.0:
+debug@^2.1.1, debug@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.1.2:
   version "1.2.0"
@@ -1922,6 +1928,10 @@ minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 ms@^0.7.1:
   version "0.7.3"


### PR DESCRIPTION
Upgraded debug fixes Regular Expression Denial of Service vulnerability https://nodesecurity.io/advisories/534.