### PR TITLE
Add custom serializer and deserializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
     - `data`: The data to serialize.
     - `options={}`: Serialization options.
         - `pretty=false`: Whether to pretty-print the result (2 spaces).
+        - `serializers={}`: Object with serialize transformation map (see below)
 
     Return value:
 
@@ -108,6 +109,7 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
     - `json`: A JSON representation of data.
     - `options={}`: Deserialization options.
         - `recordTypes={}`: `immutable.Record` factories.
+        - `deserializers={}`: Object with deserialize transformation map (see below)
 
     Return value:
 
@@ -125,9 +127,51 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
         - `bigChunks=false`: Whether the serialized data should only be split into chunks based on the reader speed. By default, each data structure level is processed in its own event loop microtask which.
             - NOTE: When `bigChunks=true`, a (possibly substantial) portion of the data is serialized synchronously.
 
+        - `serializers={}`: Object with serialize transformation map (see below)
+
     Return value:
 
     - `stream.PassThrough<!Buffer>`: A readable stream emitting the JSON representation of the input (`data`).
+
+
+### Custom serialization/deserialization transformations
+
+You can map immutable record names to transformation functions which will be called on that single record. The transformation
+function is utilized as callback from your own application code.
+
+When using `serialize()`, you can pass object containing this map as option `serializers`:
+
+```
+const transformData = (data) => data.set('a', 'transformed') 
+
+JsonImmutable.serialize(dataSet, {
+  serializers: {
+    'SampleRecord': (data) => transformData 
+  },
+})
+```
+
+This options can also be utilized with `createSerializationStream` function.
+This transformation happens just before the Immutable Record is serialized so you
+can utilize instance's methods at this time.
+
+
+Similarly you can transform data when deserializing by passing option `deserializers`:
+
+```
+const transformData = (data) => data['a'] = transformed 
+
+JsonImmutable.deserialize(dataJSON, {
+  recordTypes: 'SampleRecord',
+  deserializers: {
+    'SampleRecord': (data) => transformData 
+  },
+})
+```
+
+The callback is called just before data is transformed into Immutable Record.
+
+NOTE: `serializers` and `deserializers` options only work on Immutable Record instances, nothing else.
 
 ## Running Tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-immutable",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "lib/index",
   "scripts": {
     "prepublish": "babel src/ -d lib/",

--- a/test/create-serialization-stream/_helpers.js
+++ b/test/create-serialization-stream/_helpers.js
@@ -21,11 +21,12 @@ exports.testSerializationStream = function (test, data, expectedResult) {
   })
 }
 
-exports.getSerializationStreamResult = function (data, options) {
-  const littleChunkedData = getSerializationStreamDataWithOptions(data, {})
-  const bigChunkedData = getSerializationStreamDataWithOptions(data, {
+exports.getSerializationStreamResult = function (data, options = {}) {
+  const littleChunkedData = getSerializationStreamDataWithOptions(data, options)
+  options = Object.assign(options, {
     bigChunks: true,
   })
+  const bigChunkedData = getSerializationStreamDataWithOptions(data, options)
 
   return littleChunkedData.then((littleChunkedData) => {
     return bigChunkedData.then((bigChunkedData) => {

--- a/test/create-serialization-stream/iterable.js
+++ b/test/create-serialization-stream/iterable.js
@@ -236,3 +236,25 @@ it('should serialize an immutable.Stack as an array of values', (test) => {
   })
 })
 
+
+it('should ignore serializers option', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationStreamResult(data, {
+    serializers: {
+      'SampleRecord': (data) => `${data}-transformed`,
+    }
+  })
+
+  return result.then((result) => {
+    test.deepEqual(result['data'], [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ])
+    test.pass()
+  })
+})
+

--- a/test/create-serialization-stream/plain.js
+++ b/test/create-serialization-stream/plain.js
@@ -48,3 +48,14 @@ it('should serialize an array nested in a plain object', (test) => {
     'a': [ 'b', 123 ],
   })
 })
+
+
+it('should ignore serializers option', (test) => {
+  testPlainSerializationStream(test, {
+    'a': [ 'b', 123 ],
+  }, {
+    serializers: {
+      'SampleRecord': (data) => `${data}-transformed`,
+    },
+  })
+})

--- a/test/create-serialization-stream/record.js
+++ b/test/create-serialization-stream/record.js
@@ -133,3 +133,96 @@ it('should preserve key types of an immutable.Map in immutable.Record data',
     ])
   })
 })
+
+
+it('should apply serializer for incoming data if option is present', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 5,
+    'b': 6,
+  }, 'SampleRecord')
+
+  const options = {
+    serializers: {
+      'SampleRecord': (data) => {
+        return data.set('a', '5-transformed').set('b', '6-transformed')
+      },
+    }
+  }
+
+  const data = SampleRecord()
+  const result = helpers.getSerializationStreamResult(data, options)
+
+  return result.then((result) => {
+    test.deepEqual(result['data'], {
+      'a': '5-transformed',
+      'b': '6-transformed',
+    })
+  })
+})
+
+
+it('should apply serializer only for specified record classes', (test) => {
+  const SampleRecord1 = immutable.Record({
+    'a': 5,
+    'b': 6,
+  }, 'SampleRecord1')
+
+  const SampleRecord2 = immutable.Record({
+    'a': 7,
+    'b': 8,
+  }, 'SampleRecord2')
+
+  const SampleRecord3 = immutable.Record({
+    'x': 10,
+    'y': 20,
+  }, 'SampleRecord3')
+
+  const data = immutable.Map({
+    's1': SampleRecord1(),
+    's2': SampleRecord2(),
+    's3': SampleRecord3(),
+  })
+
+  const options = {
+    serializers: {
+      'SampleRecord1': (data) => {
+        return data.set('a', '5-transformed').set('b', '6-transformed')
+      },
+      'SampleRecord3': (data) => {
+        return data.set('x', data.get('x') + 10)
+                   .set('y', data.get('y') + 10)
+      },
+    }
+  }
+
+  const result = helpers.getSerializationStreamResult(data, options)
+
+  return result.then((result) => {
+    test.deepEqual(result, {
+      '__iterable': 'Map',
+      'data': [
+        ['s1', {
+          '__record': 'SampleRecord1',
+          'data': {
+            'a': '5-transformed',
+            'b': '6-transformed',
+          }
+        }],
+        ['s2', {
+          '__record': 'SampleRecord2',
+          'data': {
+            'a': 7,
+            'b': 8,
+          }
+        }],
+        ['s3', {
+          '__record': 'SampleRecord3',
+          'data': {
+            'x': 20,
+            'y': 30,
+          }
+        }],
+      ]
+    })
+  })
+})

--- a/test/deserialize/iterable.js
+++ b/test/deserialize/iterable.js
@@ -156,3 +156,21 @@ it('should not deserialize an iterable of an unknown type', (test) => {
     test.getDeserializationResult(data)
   })
 })
+
+
+it('should ignore deserializers option', (test) => {
+  const data = {
+    '__iterable': 'Map',
+    'data': [
+      [ 'a', 5 ],
+      [ 'b', 6 ],
+    ],
+  }
+
+  helpers.testDeserialization(test, data, immutable.Map(data['data']), {
+    deserializers: {
+      'Sample': (data) => `${data}-transformed`,
+    },
+  })
+})
+

--- a/test/deserialize/native-objects.js
+++ b/test/deserialize/native-objects.js
@@ -23,3 +23,14 @@ it('should deserialize a RegExp object with flags', (test) => {
 
   helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$', 'ig'))
 })
+
+
+it('should ignore deserializers option', (test) => {
+  const data = { '__regexp': '/(what)?\\w+$/ig' }
+
+  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$', 'ig'), {
+    deserializers: {
+      'Sample': (data) => `${data}-transformed`,
+    },
+  })
+})

--- a/test/deserialize/plain.js
+++ b/test/deserialize/plain.js
@@ -3,8 +3,8 @@ import it from 'ava'
 import helpers from './_helpers'
 
 
-function testPlainDeserialization(test, data) {
-  return helpers.testDeserialization(test, data, data)
+function testPlainDeserialization(test, data, options) {
+  return helpers.testDeserialization(test, data, data, options)
 }
 
 
@@ -44,6 +44,18 @@ it('should deserialize a nested plain object', (test) => {
 it('should deserialize an array nested in a plain object', (test) => {
   testPlainDeserialization(test, {
     'a': [ 'b', 123 ],
+  })
+})
+
+
+it('should ignore deserializers option', (test) => {
+  testPlainDeserialization(test, {
+    'a': 5,
+    'b': 6,
+  }, {
+    deserializers: {
+      'Sample': (data) => `${data}-transformed`,
+    },
   })
 })
 

--- a/test/deserialize/record.js
+++ b/test/deserialize/record.js
@@ -183,3 +183,97 @@ it('should use the result of the migrate method', (test) => {
     },
   })
 })
+
+
+it('should apply deserializer onto outcoming data if option is present', (test) => {
+  const SampleRecord = immutable.Record({
+    'a': 1,
+    'b': 2,
+  }, 'SampleRecord')
+
+  const data = {
+    '__record': 'SampleRecord',
+    'data': {
+      'a': 5,
+      'b': 6,
+    },
+  }
+
+  const expectedResult = SampleRecord({
+    'a': '5-transformed',
+    'b': '6-transformed'
+  })
+
+  helpers.testDeserialization(test, data, expectedResult, {
+    recordTypes: {
+      'SampleRecord': SampleRecord,
+    },
+    deserializers: { 
+      'SampleRecord': (data) => {
+        return Object.assign(data, {
+          'a': `${data['a']}-transformed`,
+          'b': `${data['b']}-transformed`,
+        }) 
+      },
+    },
+  })
+})
+
+
+it('should apply deserializer only to specified record classes', (test) => {
+  const SampleRecord1 = immutable.Record({
+    'a': 1,
+    'b': 2,
+  }, 'SampleRecord1')
+
+  const SampleRecord2 = immutable.Record({
+    'a': 3,
+    'b': 4,
+  }, 'SampleRecord2')
+
+  const data = {
+    '__iterable': 'Map',
+    'data': {
+      's1': {
+        '__record': 'SampleRecord1',
+        'data': {
+          'a': 1,
+          'b': 2,
+        },
+      },
+      's2': {
+        '__record': 'SampleRecord2',
+        'data': {
+          'a': 3,
+          'b': 4,
+        },
+      }
+    }
+  }
+
+  const expectedResult = immutable.Map({
+    's1': SampleRecord1({
+      'a': '1-transformed',
+      'b': '2-transformed'
+    }),
+    's2': SampleRecord2({
+      'a': 3,
+      'b': 4,
+    })
+  })
+
+  helpers.testDeserialization(test, data, expectedResult, {
+    recordTypes: {
+      'SampleRecord1': SampleRecord1,
+      'SampleRecord2': SampleRecord2,
+    },
+    deserializers: { 
+      'SampleRecord1': (data) => {
+        return Object.assign(data, {
+          'a': `${data['a']}-transformed`,
+          'b': `${data['b']}-transformed`,
+        }) 
+      },
+    },
+  })
+})

--- a/test/serialize/_helpers.js
+++ b/test/serialize/_helpers.js
@@ -1,12 +1,12 @@
 const JsonImmutable = require('../../lib/')
 
 
-exports.testSerialization = function (test, data, expectedResult) {
-  const result = exports.getSerializationResult(data)
+exports.testSerialization = function (test, data, expectedResult, options) {
+  const result = exports.getSerializationResult(data, options)
   test.deepEqual(result, expectedResult)
 }
 
-exports.getSerializationResult = function (data) {
-  const json = JsonImmutable.serialize(data)
+exports.getSerializationResult = function (data, options) {
+  const json = JsonImmutable.serialize(data, options || {})
   return JSON.parse(json)
 }

--- a/test/serialize/iterable.js
+++ b/test/serialize/iterable.js
@@ -189,3 +189,21 @@ it('should serialize an immutable.Stack as an array of values', (test) => {
   test.deepEqual(result['data'], [ 5, 6 ])
 })
 
+
+it('should ignore serializers option', (test) => {
+  const data = immutable.Map({
+    'a': 5,
+    'b': 6,
+  })
+
+  const result = helpers.getSerializationResult(data, {
+    serializers: {
+      'SampleRecord': (data) => `${data}-transformed`,
+    },
+  })
+  test.deepEqual(result['data'], [
+    [ 'a', 5 ],
+    [ 'b', 6 ],
+  ])
+})
+

--- a/test/serialize/native-objects.js
+++ b/test/serialize/native-objects.js
@@ -26,3 +26,15 @@ it('should serialize a RegExp object with flags', (test) => {
 
   test.is(result['__regexp'], regexp.toString())
 })
+
+
+it('should ignore serializers option', (test) => {
+  const regexp = new RegExp('(what)?\\w+$', 'ig')
+  const result = helpers.getSerializationResult(regexp, {
+    serializers: {
+      'SampleRecord': (data) => `${data}-transformed`,
+    },
+  })
+
+  test.is(result['__regexp'], regexp.toString())
+})

--- a/test/serialize/plain.js
+++ b/test/serialize/plain.js
@@ -3,8 +3,8 @@ import it from 'ava'
 import helpers from './_helpers'
 
 
-function testPlainSerialization(test, data) {
-  return helpers.testSerialization(test, data, data)
+function testPlainSerialization(test, data, options) {
+  return helpers.testSerialization(test, data, data, options)
 }
 
 
@@ -46,5 +46,16 @@ it('should serialize a nested plain object', (test) => {
 it('should serialize an array nested in a plain object', (test) => {
   testPlainSerialization(test, {
     'a': [ 'b', 123 ],
+  })
+})
+
+
+it('should ignore serializers option', (test) => {
+  testPlainSerialization(test, {
+    'a': [ 'b', 123 ],
+  }, {
+    serializers: {
+      'SampleRecord': (data) => `${data}-transformed`,
+    },
   })
 })


### PR DESCRIPTION
This adds two new options: 

1. `serializers`
2. `deserializers`

Both options are javascript objects where keys are name of the immutable Record (as in `_name` attribute). The value is a callback which can be applied before the final serialization/deserialization occurs.